### PR TITLE
cli: Migrate to clap Derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -246,6 +247,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -480,6 +493,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-process = "1.8.1"
 bincode = "1.3.3"
-clap = "4.4.7"
+clap = { version = "4.4.7", features = ["derive"] }
 dag = { git = "https://github.com/serpent-os/moss-rs.git", version = "0.1.0" }
 futures = "0.3.29"
 regex = "1.10.2"

--- a/src/bin/usysconf/cli/mod.rs
+++ b/src/bin/usysconf/cli/mod.rs
@@ -2,21 +2,32 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use clap::Command;
+use clap::{Parser, Subcommand};
 use thiserror::Error;
 
-/// Generate the CLI command structure
-fn command() -> Command {
-    Command::new("usysconf")
-        .about("Univeral system configuration")
-        .long_about("System configuration agent for modern Linux distributions to handle a variety of installation and removal triggers")
-        .arg_required_else_help(true)
+#[derive(Parser)]
+#[command(author, version = None)]
+#[command(about = "Universal system configuration")]
+#[command(long_about = "System configuration agent for modern linux distributions to handle a variety of installation and removal triggers")]
+#[command(arg_required_else_help = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
 }
+
+#[derive(Subcommand)]
+enum Commands {}
 
 /// Process CLI arguments for usysconf binary
 pub fn process() -> Result<(), Error> {
-    let _ = command().get_matches();
-    Err(Error::NotImplemented)
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Some(_) => return Err(Error::NotImplemented),
+        None => {}
+    };
+
+    Ok(())
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Simple enough: just migrates the CLI to using the Derive feature of clap.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
